### PR TITLE
ci: macos-latest is now macos-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: [ubuntu-latest, macos-13, windows-latest]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
ARM is fine, but no Python 3.8 or 3.9 is not.