### PR TITLE
chore: filter pre-commit and dependabot from changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
This makes the auto-changelog generation smarter, reducing manual work required.
