### PR TITLE
ci: automatically merge the weekly “update the stored schema files” PRs and release them automatically

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,33 @@
+name: Create release on pyproject-schema-store-bot merge
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  create-release:
+    if:
+      github.event.pull_request.merged == true && github.actor ==
+      'pyproject-schema-store-bot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get version from pyproject.toml
+        id: get_version
+        uses: mikefarah/yq@v4
+        with:
+          cmd: yq .project.version pyproject.toml
+      - name: Create git tag
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@users.noreply.github.com
+          git tag ${{ steps.get_version.outputs.result }}
+          git push origin ${{ steps.get_version.outputs.result }}
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.get_version.outputs.result }}
+          token: ${{ secrets.token }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -2,7 +2,7 @@ name: Bump
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 8 * * 1" # "At 08:00 on Monday"
+    - cron: 0 8 * * * # At 08:00 every day
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -50,6 +50,7 @@ jobs:
               print(f"version={pyproject['project']['version']}", file=f)
 
       - uses: peter-evans/create-pull-request@v7
+        id: create-pr
         with:
           title: |
             chore(deps): bump version to ${{ steps.getver.outputs.version }}
@@ -63,3 +64,10 @@ jobs:
           delete-branch: true
           token: ${{ steps.generate-token.outputs.token }}
           sign-commits: true
+
+      - name: Enable pull request auto-merge
+        run:
+          gh pr merge --merge --auto ${{
+          steps.create-pr.outputs.pull-request-number }}
+        env:
+          GH_TOKEN: ${{ secrets.token }}


### PR DESCRIPTION
The repository administrator needs to:
  - enable "Allow auto-merge" in the repository settings
  - set all PR checks to "Required", otherwise PRs with failing checks will be merged automatically.
  - add a GitHub token named `token` in the repository secrets, which requires `content` permissions.

Close #144