### PR TITLE
ci: fix auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,8 +5,8 @@ on:
 jobs:
   create-release:
     if:
-      github.event.pull_request.merged == true && github.actor ==
-      'pyproject-schema-store-bot[bot]'
+      github.event.pull_request.merged == true &&
+      github.event.head_commit.author.name == 'pyproject-schema-store-bot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
### The problem
> I think https://github.com/henryiii/validate-pyproject-schema-store/actions/runs/16782233722 shouldn't have skipped?

#152 was merged this way:

<img width="578" height="78" alt="image" src="https://github.com/user-attachments/assets/56437dd4-60b2-4286-9d4d-1f3652709601" />

Because automatic merging uses the PAT from your GitHub account, `github.actor` is `henryiii` instead of `pyproject-schema-store-bot[bot]`.

https://github.com/henryiii/validate-pyproject-schema-store/blob/189393f9065459a87c6d4152525a09dda73daf68/.github/workflows/auto-release.yml#L6-L9

### Possible solution

> [!CAUTION]
> 1. None of the solutions below have been tested by me; they are only theoretically feasible.
> 2. Any one of the following three solutions will suffice.

1. The simplest solution is to change the condition to `github.event.head_commit.author.name == 'pyproject-schema-store-bot[bot]'`, i.e., this PR.
  Limitations:
    - If there’s an autofix from pre-commit.ci, it will cause the condition to fail, so this method is not perfect.
    - If someone else submits a PR with `author.name` also set to `'pyproject-schema-store-bot[bot]'`, it will trigger a release as well. To prevent malicious PRs, this can be addressed through commit signature verification.
3. You can register a new human GitHub account dedicated to auto-merge/auto-release, then replace `secrets.token` with the PAT from that account, and update `github.actor` to that account’s username.
4. Grant `pyproject-schema-store-bot[bot]` sufficient permissions and use its token to authorize auto-merge. Alternatively, rewrite `pyproject-schema-store-bot[bot]`’s code so that it performs the auto-merge itself.



