### PR TITLE
Revert "chore(deps): bump version to 2025.08.06 (#152)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "validate-pyproject-schema-store"
-version = "2025.08.06"
+version = "2025.07.28"
 authors = [
   { name = "Henry Schreiner", email = "henryfs@princeton.edu" },
 ]

--- a/src/validate_pyproject_schema_store/resources/ruff.schema.json
+++ b/src/validate_pyproject_schema_store/resources/ruff.schema.json
@@ -810,15 +810,6 @@
             "boolean",
             "null"
           ]
-        },
-        "string-imports-min-dots": {
-          "description": "The minimum number of dots in a string to consider it a valid import.\n\nThis setting is only relevant when [`detect-string-imports`](#detect-string-imports) is enabled. For example, if this is set to `2`, then only strings with at least two dots (e.g., `\"path.to.module\"`) would be considered valid imports.",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint",
-          "minimum": 0.0
         }
       },
       "additionalProperties": false
@@ -2289,13 +2280,6 @@
             {
               "type": "null"
             }
-          ]
-        },
-        "future-annotations": {
-          "description": "Whether to allow rules to add `from __future__ import annotations` in cases where this would simplify a fix or enable a new diagnostic.\n\nFor example, `TC001`, `TC002`, and `TC003` can move more imports into `TYPE_CHECKING` blocks if `__future__` annotations are enabled.\n\nThis setting is currently in [preview](https://docs.astral.sh/ruff/preview/) and requires preview mode to be enabled to have any effect.",
-          "type": [
-            "boolean",
-            "null"
           ]
         },
         "ignore": {


### PR DESCRIPTION
Reverting this so we can try again. See #153.
