### PR TITLE
ci: fix auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,7 +6,7 @@ jobs:
   create-release:
     if:
       github.event.pull_request.merged == true &&
-      github.event.head_commit.author.name == 'pyproject-schema-store-bot[bot]'
+      github.event.pull_request.user.login == 'pyproject-schema-store-bot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -66,6 +66,7 @@ jobs:
           sign-commits: true
 
       - name: Enable pull request auto-merge
+        if: steps.create-pr.outputs.pull-request-number
         run:
           gh pr merge --rebase --auto --delete-branch ${{
           steps.create-pr.outputs.pull-request-number }}


### PR DESCRIPTION
Now, not creating a PR will no longer cause the workflow run to fail, and it should no longer cause the "create-release" job to be skipped.

Everything should be working fine now.