### PR TITLE
ci: change the merge method back to `squash` in order to obtain a signed commit

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Enable pull request auto-merge
         if: steps.create-pr.outputs.pull-request-number
         run:
-          gh pr merge --rebase --auto --delete-branch ${{
+          gh pr merge --squash --auto --delete-branch ${{
           steps.create-pr.outputs.pull-request-number }}
         env:
           GH_TOKEN: ${{ secrets.token }}


### PR DESCRIPTION
There will be no signature when the merge method is set to **rebase**.

<img width="1580" height="353" alt="image" src="https://github.com/user-attachments/assets/e9a303f8-b9c8-49a9-88f0-f4f04f0eff91" />