### PR TITLE
ci: only automerge for bot commits

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -70,8 +70,8 @@ jobs:
         if: steps.create-pr.outputs.pull-request-number
         run: |
           pr_number=${{ steps.create-pr.outputs.pull-request-number }}
-          commits=$(gh api repos/${{ github.repository }}/pulls/$pr_number/commits --jq '[.[].author.login]')
-          unique_authors=$(echo "$commits" | jq 'unique')
+          commits=$(gh api repos/${{ github.repository }}/pulls/$pr_number/commits --jq '[.[].author.login? // "unknown"]')
+          unique_authors=$(echo "$commits" | jq -c 'unique')
           echo "authors=$unique_authors" >> "$GITHUB_OUTPUT"
           if [[ "$unique_authors" == '["pyproject-schema-store-bot[bot]"]' ]]; then
             echo "only-bot=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -83,7 +83,9 @@ jobs:
           GH_TOKEN: ${{ secrets.token }}
 
       - name: Enable pull request auto-merge
-        if: steps.create-pr.outputs.pull-request-number && steps.check-commits.outputs.only-bot == 'true'
+        if:
+          steps.create-pr.outputs.pull-request-number &&
+          steps.check-commits.outputs.only-bot == 'true'
         run: |
           gh pr merge --squash --auto --delete-branch ${{ steps.create-pr.outputs.pull-request-number }}
         env:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -65,10 +65,26 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           sign-commits: true
 
-      - name: Enable pull request auto-merge
+      - name: Check all commits are from bot
+        id: check-commits
         if: steps.create-pr.outputs.pull-request-number
-        run:
-          gh pr merge --squash --auto --delete-branch ${{
-          steps.create-pr.outputs.pull-request-number }}
+        run: |
+          pr_number=${{ steps.create-pr.outputs.pull-request-number }}
+          commits=$(gh api repos/${{ github.repository }}/pulls/$pr_number/commits --jq '[.[].author.login]')
+          unique_authors=$(echo "$commits" | jq 'unique')
+          echo "authors=$unique_authors" >> "$GITHUB_OUTPUT"
+          if [[ "$unique_authors" == '["pyproject-schema-store-bot[bot]"]' ]]; then
+            echo "only-bot=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "only-bot=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping auto-merge: PR has commits from: $unique_authors"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.token }}
+
+      - name: Enable pull request auto-merge
+        if: steps.create-pr.outputs.pull-request-number && steps.check-commits.outputs.only-bot == 'true'
+        run: |
+          gh pr merge --squash --auto --delete-branch ${{ steps.create-pr.outputs.pull-request-number }}
         env:
           GH_TOKEN: ${{ secrets.token }}


### PR DESCRIPTION
This keeps auto-merge from triggering if I add a commit to a bot PR.

:robot: Assisted-by: OpenCode:Kimi-K2.5
