### PR TITLE
fix: support relative urls

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: generate-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "validate-pyproject-schema-store"
-version = "2026.04.26"
+version = "2026.05.01"
 authors = [
   { name = "Henry Schreiner", email = "henryfs@princeton.edu" },
 ]

--- a/src/validate_pyproject_schema_store/resources/maturin.schema.json
+++ b/src/validate_pyproject_schema_store/resources/maturin.schema.json
@@ -1,6 +1,634 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/maturin.json",
+  "$defs": {
+    "AuditWheelMode": {
+      "description": "Auditwheel mode",
+      "oneOf": [
+        {
+          "description": "Audit and repair wheel for manylinux compliance",
+          "type": "string",
+          "const": "repair"
+        },
+        {
+          "description": "Check wheel for manylinux compliance, but do not repair",
+          "type": "string",
+          "const": "check"
+        },
+        {
+          "description": "Audit wheel and warn about external libraries, but do not fail or repair",
+          "type": "string",
+          "const": "warn"
+        },
+        {
+          "description": "Don't check for manylinux compliance",
+          "type": "string",
+          "const": "skip"
+        }
+      ]
+    },
+    "CargoCrateType": {
+      "description": "Supported cargo crate types",
+      "oneOf": [
+        {
+          "description": "Binary executable target",
+          "type": "string",
+          "const": "bin"
+        },
+        {
+          "description": "Dynamic system library target",
+          "type": "string",
+          "const": "cdylib"
+        },
+        {
+          "description": "Dynamic Rust library target",
+          "type": "string",
+          "const": "dylib"
+        },
+        {
+          "description": "Rust library",
+          "type": "string",
+          "const": "lib"
+        },
+        {
+          "description": "Rust library for use as an intermediate target",
+          "type": "string",
+          "const": "rlib"
+        },
+        {
+          "description": "Static library",
+          "type": "string",
+          "const": "staticlib"
+        }
+      ]
+    },
+    "CargoTarget": {
+      "description": "Cargo compile target",
+      "type": "object",
+      "properties": {
+        "kind": {
+          "description": "Kind of target (\"bin\", \"cdylib\")",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CargoCrateType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "description": "Name as given in the `Cargo.toml` or generated from the file name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "FeatureSpec": {
+      "description": "A cargo feature specification that can be either a plain feature name\nor a conditional feature that is only enabled for certain Python versions.\n\n# Examples\n\n```toml\n[tool.maturin]\nfeatures = [\n  \"some-feature\",\n  { feature = \"pyo3/abi3-py311\", python-version = \">=3.11\" },\n  { feature = \"pyo3/abi3-py38\", python-version = \"<3.11\" },\n  { feature = \"pyo3/abi3-py311\", python-version = \">=3.11\", python-implementation = \"cpython\" },\n  { feature = \"pypy-compat\", python-implementation = \"pypy\" },\n]\n```",
+      "anyOf": [
+        {
+          "description": "A plain feature name, always enabled",
+          "type": "string"
+        },
+        {
+          "description": "A feature enabled only when the conditions match",
+          "type": "object",
+          "properties": {
+            "feature": {
+              "description": "The cargo feature to enable",
+              "type": "string"
+            },
+            "python-implementation": {
+              "description": "Python implementation name, e.g. \"cpython\", \"pypy\", \"graalpy\"",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "python-version": {
+              "description": "PEP 440 version specifier for the target Python version, e.g. \">=3.11\"",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "feature"
+          ]
+        }
+      ]
+    },
+    "Format": {
+      "description": "The target format for the include or exclude [GlobPattern].\n\nSee [Formats].",
+      "oneOf": [
+        {
+          "description": "Source distribution",
+          "type": "string",
+          "const": "sdist"
+        },
+        {
+          "description": "Wheel",
+          "type": "string",
+          "const": "wheel"
+        }
+      ]
+    },
+    "Formats": {
+      "description": "A single [Format] or multiple [Format] values for a [GlobPattern].",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Format",
+          "description": "A single [Format] value"
+        },
+        {
+          "description": "Multiple [Format] values",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Format"
+          }
+        }
+      ]
+    },
+    "GenerateCIConfig": {
+      "description": "The `[tool.maturin.generate-ci]` section",
+      "type": "object",
+      "properties": {
+        "github": {
+          "description": "GitHub Actions configuration",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GitHubCIConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "GitHubCIConfig": {
+      "description": "The `[tool.maturin.generate-ci.github]` section",
+      "type": "object",
+      "properties": {
+        "android": {
+          "description": "Android platform configuration",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PlatformCIConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "args": {
+          "description": "Extra arguments to pass to maturin (applies to all platforms)",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "emscripten": {
+          "description": "Emscripten platform configuration",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PlatformCIConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "linux": {
+          "description": "Linux (manylinux) platform configuration",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PlatformCIConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "macos": {
+          "description": "macOS platform configuration",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PlatformCIConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "musllinux": {
+          "description": "Musllinux platform configuration",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PlatformCIConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pytest": {
+          "description": "Enable pytest",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "skip-attestation": {
+          "description": "Skip artifact attestation",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "windows": {
+          "description": "Windows platform configuration",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PlatformCIConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "zig": {
+          "description": "Use zig for cross compilation",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "GlobPattern": {
+      "description": "A glob pattern for the include and exclude configuration.\n\nSee [PyProjectToml::include] and [PyProject::exclude].\n\nBased on <https://python-poetry.org/docs/pyproject/#include-and-exclude>.",
+      "anyOf": [
+        {
+          "description": "A glob",
+          "type": "string"
+        },
+        {
+          "description": "A glob `path` with a `format` key to specify one or more [Format] values",
+          "type": "object",
+          "properties": {
+            "format": {
+              "$ref": "#/$defs/Formats",
+              "description": "One or more [Format] values"
+            },
+            "path": {
+              "description": "A glob",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "format"
+          ]
+        },
+        {
+          "description": "A glob `path` relative to a crate's OUT_DIR",
+          "type": "object",
+          "properties": {
+            "crate_name": {
+              "description": "Optional crate name (defaults to the root crate)",
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "from": {
+              "$ref": "#/$defs/IncludeFrom",
+              "description": "Source: must be \"out-dir\""
+            },
+            "path": {
+              "description": "A glob pattern relative to OUT_DIR",
+              "type": "string"
+            },
+            "to": {
+              "description": "Target path in wheel (e.g. \"my_package/\")",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "from",
+            "to"
+          ]
+        }
+      ]
+    },
+    "IncludeFrom": {
+      "description": "Supported values for the `from` field in include patterns.",
+      "oneOf": [
+        {
+          "description": "Include files from the crate's OUT_DIR",
+          "type": "string",
+          "const": "out-dir"
+        }
+      ]
+    },
+    "PlatformCIConfig": {
+      "description": "Per-platform CI configuration",
+      "type": "object",
+      "properties": {
+        "args": {
+          "description": "Extra arguments to pass to maturin",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "before-script-linux": {
+          "description": "Script to run before build on Linux",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "container": {
+          "description": "Container image to use",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "docker-options": {
+          "description": "Docker options",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "manylinux": {
+          "description": "Manylinux version (e.g. \"auto\", \"2_28\", \"musllinux_1_2\")",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "runner": {
+          "description": "Default runner for this platform",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rust-toolchain": {
+          "description": "Rust toolchain (e.g. \"nightly\", \"stable\")",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rustup-components": {
+          "description": "Rustup components to install",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "target": {
+          "description": "Detailed per-target configuration (mutually exclusive with `targets`)",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/TargetCIConfig"
+          }
+        },
+        "targets": {
+          "description": "Simple list of target architectures (mutually exclusive with `target`)",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PlatformTag": {
+      "description": "Decides how to handle manylinux and musllinux compliance",
+      "oneOf": [
+        {
+          "description": "Use the `manylinux_<major>_<minor>` tag",
+          "type": "object",
+          "properties": {
+            "Manylinux": {
+              "type": "object",
+              "properties": {
+                "major": {
+                  "description": "GLIBC version major",
+                  "type": "integer",
+                  "format": "uint16",
+                  "maximum": 65535,
+                  "minimum": 0
+                },
+                "minor": {
+                  "description": "GLIBC version minor",
+                  "type": "integer",
+                  "format": "uint16",
+                  "maximum": 65535,
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "major",
+                "minor"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "Manylinux"
+          ]
+        },
+        {
+          "description": "Use the `musllinux_<major>_<minor>` tag",
+          "type": "object",
+          "properties": {
+            "Musllinux": {
+              "type": "object",
+              "properties": {
+                "major": {
+                  "description": "musl libc version major",
+                  "type": "integer",
+                  "format": "uint16",
+                  "maximum": 65535,
+                  "minimum": 0
+                },
+                "minor": {
+                  "description": "musl libc version minor",
+                  "type": "integer",
+                  "format": "uint16",
+                  "maximum": 65535,
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "major",
+                "minor"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "Musllinux"
+          ]
+        },
+        {
+          "description": "Use the native linux tag",
+          "type": "string",
+          "const": "Linux"
+        },
+        {
+          "description": "Ensure that a PyPI-compatible tag is used, error if the target is not supported by PyPI.",
+          "type": "string",
+          "const": "Pypi"
+        }
+      ]
+    },
+    "SbomConfig": {
+      "description": "SBOM configuration",
+      "type": "object",
+      "properties": {
+        "auditwheel": {
+          "description": "Generate a CycloneDX SBOM for external shared libraries grafted during\nauditwheel repair. Defaults to `true` when repair copies libraries.\n\nThe SBOM is written to `<dist-info>/sboms/auditwheel.cdx.json` and\nrecords which OS packages (deb, rpm, apk) provided the grafted\nlibraries, following the same convention as Python's auditwheel.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "include": {
+          "description": "Additional SBOM files to include in the `.dist-info/sboms` directory.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "rust": {
+          "description": "Generate an SBOM for Rust crates. Defaults to `true`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "SdistGenerator": {
+      "description": "Source distribution generator",
+      "oneOf": [
+        {
+          "description": "Use `cargo package --list`",
+          "type": "string",
+          "const": "cargo"
+        },
+        {
+          "description": "Use `git ls-files`",
+          "type": "string",
+          "const": "git"
+        }
+      ]
+    },
+    "TargetCIConfig": {
+      "description": "Per-target CI configuration within a platform",
+      "type": "object",
+      "properties": {
+        "arch": {
+          "description": "Target architecture (e.g. \"x86_64\", \"aarch64\")",
+          "type": "string"
+        },
+        "args": {
+          "description": "Extra arguments to pass to maturin",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "before-script-linux": {
+          "description": "Before-script-linux override",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "container": {
+          "description": "Container image override",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "docker-options": {
+          "description": "Docker options override",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "manylinux": {
+          "description": "Manylinux version override",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "runner": {
+          "description": "Runner override for this target",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rust-toolchain": {
+          "description": "Rust toolchain override",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rustup-components": {
+          "description": "Rustup components override",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "arch"
+      ]
+    },
+    "TargetConfig": {
+      "description": "Target configuration",
+      "type": "object",
+      "properties": {
+        "macos-deployment-target": {
+          "description": "macOS deployment target version",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  },
   "title": "ToolMaturin",
   "description": "The `[tool.maturin]` section of a pyproject.toml",
   "type": "object",
@@ -17,7 +645,7 @@
       "description": "Audit wheel mode",
       "anyOf": [
         {
-          "$ref": "#/definitions/AuditWheelMode"
+          "$ref": "#/$defs/AuditWheelMode"
         },
         {
           "type": "null"
@@ -35,7 +663,7 @@
       "description": "Platform compatibility",
       "anyOf": [
         {
-          "$ref": "#/definitions/PlatformTag"
+          "$ref": "#/$defs/PlatformTag"
         },
         {
           "type": "null"
@@ -59,14 +687,21 @@
         "null"
       ]
     },
+    "editable-profile": {
+      "description": "Same as `profile` but for \"editable\" builds",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "exclude": {
-      "description": "Exclude files matching the given glob pattern(s)",
+      "description": "Exclude files matching the given glob pattern(s).\nPatterns are resolved relative to the directory containing `pyproject.toml`.",
       "type": [
         "array",
         "null"
       ],
       "items": {
-        "$ref": "#/definitions/GlobPattern"
+        "$ref": "#/$defs/GlobPattern"
       }
     },
     "features": {
@@ -76,7 +711,7 @@
         "null"
       ],
       "items": {
-        "$ref": "#/definitions/FeatureSpec"
+        "$ref": "#/$defs/FeatureSpec"
       }
     },
     "frozen": {
@@ -86,15 +721,31 @@
         "null"
       ]
     },
+    "generate-ci": {
+      "description": "CI generation configuration",
+      "anyOf": [
+        {
+          "$ref": "#/$defs/GenerateCIConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "include": {
-      "description": "Include files matching the given glob pattern(s)",
+      "description": "Include files matching the given glob pattern(s).\nPatterns are resolved relative to the directory containing `pyproject.toml`.\nWhen `python-source` is configured, patterns are also tried relative to\nthat directory if no matches are found.",
       "type": [
         "array",
         "null"
       ],
       "items": {
-        "$ref": "#/definitions/GlobPattern"
+        "$ref": "#/$defs/GlobPattern"
       }
+    },
+    "include-import-lib": {
+      "description": "Include the import library (.dll.lib) in the wheel on Windows",
+      "type": "boolean",
+      "default": false
     },
     "locked": {
       "description": "Require Cargo.lock is up to date",
@@ -158,32 +809,39 @@
         "type": "string"
       }
     },
-    "sdist-generator": {
-      "description": "Source distribution generator",
-      "default": "cargo",
-      "allOf": [
+    "sbom": {
+      "description": "SBOM configuration",
+      "anyOf": [
         {
-          "$ref": "#/definitions/SdistGenerator"
+          "$ref": "#/$defs/SbomConfig"
+        },
+        {
+          "type": "null"
         }
       ]
     },
+    "sdist-generator": {
+      "$ref": "#/$defs/SdistGenerator",
+      "description": "Source distribution generator",
+      "default": "cargo"
+    },
     "skip-auditwheel": {
       "description": "Skip audit wheel",
-      "default": false,
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "strip": {
       "description": "Strip the final binary",
-      "default": false,
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "target": {
       "description": "Target configuration",
-      "default": {},
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/definitions/TargetConfig"
-      }
+        "$ref": "#/$defs/TargetConfig"
+      },
+      "default": {}
     },
     "targets": {
       "description": "Cargo compile targets",
@@ -192,7 +850,7 @@
         "null"
       ],
       "items": {
-        "$ref": "#/definitions/CargoTarget"
+        "$ref": "#/$defs/CargoTarget"
       }
     },
     "unstable-flags": {
@@ -204,315 +862,11 @@
       "items": {
         "type": "string"
       }
-    }
-  },
-  "definitions": {
-    "AuditWheelMode": {
-      "description": "Auditwheel mode",
-      "oneOf": [
-        {
-          "description": "Audit and repair wheel for manylinux compliance",
-          "type": "string",
-          "enum": [
-            "repair"
-          ]
-        },
-        {
-          "description": "Check wheel for manylinux compliance, but do not repair",
-          "type": "string",
-          "enum": [
-            "check"
-          ]
-        },
-        {
-          "description": "Don't check for manylinux compliance",
-          "type": "string",
-          "enum": [
-            "skip"
-          ]
-        }
-      ]
     },
-    "CargoCrateType": {
-      "description": "Supported cargo crate types",
-      "oneOf": [
-        {
-          "description": "Binary executable target",
-          "type": "string",
-          "enum": [
-            "bin"
-          ]
-        },
-        {
-          "description": "Dynamic system library target",
-          "type": "string",
-          "enum": [
-            "cdylib"
-          ]
-        },
-        {
-          "description": "Dynamic Rust library target",
-          "type": "string",
-          "enum": [
-            "dylib"
-          ]
-        },
-        {
-          "description": "Rust library",
-          "type": "string",
-          "enum": [
-            "lib"
-          ]
-        },
-        {
-          "description": "Rust library for use as an intermediate target",
-          "type": "string",
-          "enum": [
-            "rlib"
-          ]
-        },
-        {
-          "description": "Static library",
-          "type": "string",
-          "enum": [
-            "staticlib"
-          ]
-        }
-      ]
-    },
-    "CargoTarget": {
-      "description": "Cargo compile target",
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "x-tombi-table-keys-order": "schema",
-      "properties": {
-        "kind": {
-          "description": "Kind of target (\"bin\", \"cdylib\")",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/CargoCrateType"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "name": {
-          "description": "Name as given in the `Cargo.toml` or generated from the file name",
-          "type": "string"
-        }
-      }
-    },
-    "FeatureSpec": {
-      "description": "A cargo feature specification that can be either a plain feature name\nor a conditional feature that is only enabled for certain Python versions.\n\n# Examples\n\n```toml\n[tool.maturin]\nfeatures = [\n  \"some-feature\",\n  { feature = \"pyo3/abi3-py311\", python-version = \">=3.11\" },\n  { feature = \"pyo3/abi3-py38\", python-version = \"<3.11\" },\n]\n```",
-      "anyOf": [
-        {
-          "description": "A plain feature name, always enabled",
-          "type": "string"
-        },
-        {
-          "description": "A feature enabled only when the target Python version matches",
-          "type": "object",
-          "properties": {
-            "feature": {
-              "description": "The cargo feature to enable",
-              "type": "string"
-            },
-            "python-version": {
-              "description": "PEP 440 version specifier for the target Python version, e.g. \">=3.11\"",
-              "type": "string"
-            }
-          },
-          "required": [
-            "feature",
-            "python-version"
-          ]
-        }
-      ]
-    },
-    "Format": {
-      "description": "The target format for the include or exclude [GlobPattern].\n\nSee [Formats].",
-      "oneOf": [
-        {
-          "description": "Source distribution",
-          "type": "string",
-          "enum": [
-            "sdist"
-          ]
-        },
-        {
-          "description": "Wheel",
-          "type": "string",
-          "enum": [
-            "wheel"
-          ]
-        }
-      ]
-    },
-    "Formats": {
-      "description": "A single [Format] or multiple [Format] values for a [GlobPattern].",
-      "anyOf": [
-        {
-          "description": "A single [Format] value",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Format"
-            }
-          ]
-        },
-        {
-          "description": "Multiple [Format] values",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Format"
-          }
-        }
-      ]
-    },
-    "GlobPattern": {
-      "description": "A glob pattern for the include and exclude configuration.\n\nSee [PyProjectToml::include] and [PyProject::exclude].\n\nBased on <https://python-poetry.org/docs/pyproject/#include-and-exclude>.",
-      "anyOf": [
-        {
-          "description": "A glob",
-          "type": "string"
-        },
-        {
-          "description": "A glob `path` with a `format` key to specify one or more [Format] values",
-          "type": "object",
-          "required": [
-            "format",
-            "path"
-          ],
-          "x-tombi-table-keys-order": "schema",
-          "properties": {
-            "format": {
-              "description": "One or more [Format] values",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/Formats"
-                }
-              ]
-            },
-            "path": {
-              "description": "A glob",
-              "type": "string"
-            }
-          }
-        }
-      ]
-    },
-    "PlatformTag": {
-      "description": "Decides how to handle manylinux and musllinux compliance",
-      "oneOf": [
-        {
-          "description": "Use the manylinux_x_y tag",
-          "type": "object",
-          "required": [
-            "Manylinux"
-          ],
-          "x-tombi-table-keys-order": "schema",
-          "properties": {
-            "Manylinux": {
-              "type": "object",
-              "required": [
-                "x",
-                "y"
-              ],
-              "x-tombi-table-keys-order": "schema",
-              "properties": {
-                "x": {
-                  "description": "GLIBC version major",
-                  "type": "integer",
-                  "format": "uint16",
-                  "minimum": 0.0
-                },
-                "y": {
-                  "description": "GLIBC version minor",
-                  "type": "integer",
-                  "format": "uint16",
-                  "minimum": 0.0
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Use the musllinux_x_y tag",
-          "type": "object",
-          "required": [
-            "Musllinux"
-          ],
-          "x-tombi-table-keys-order": "schema",
-          "properties": {
-            "Musllinux": {
-              "type": "object",
-              "required": [
-                "x",
-                "y"
-              ],
-              "x-tombi-table-keys-order": "schema",
-              "properties": {
-                "x": {
-                  "description": "musl libc version major",
-                  "type": "integer",
-                  "format": "uint16",
-                  "minimum": 0.0
-                },
-                "y": {
-                  "description": "musl libc version minor",
-                  "type": "integer",
-                  "format": "uint16",
-                  "minimum": 0.0
-                }
-              }
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Use the native linux tag",
-          "type": "string",
-          "enum": [
-            "Linux"
-          ]
-        }
-      ]
-    },
-    "SdistGenerator": {
-      "description": "Source distribution generator",
-      "oneOf": [
-        {
-          "description": "Use `cargo package --list`",
-          "type": "string",
-          "enum": [
-            "cargo"
-          ]
-        },
-        {
-          "description": "Use `git ls-files`",
-          "type": "string",
-          "enum": [
-            "git"
-          ]
-        }
-      ]
-    },
-    "TargetConfig": {
-      "description": "Target configuration",
-      "type": "object",
-      "x-tombi-table-keys-order": "schema",
-      "properties": {
-        "macos-deployment-target": {
-          "description": "macOS deployment target version",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      }
+    "use-base-python": {
+      "description": "Use base Python executable instead of venv Python executable in PEP 517 build.",
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/src/validate_pyproject_schema_store/resources/ty.schema.json
+++ b/src/validate_pyproject_schema_store/resources/ty.schema.json
@@ -621,6 +621,16 @@
             }
           ]
         },
+        "invalid-attribute-override": {
+          "title": "detects attribute overrides that change class-variable or instance-variable behavior",
+          "description": "## What it does\nDetects attribute overrides that change whether an inherited attribute\nis a class variable or an instance variable.\n\nThis rule currently only covers class-variable and instance-variable\ncategory changes.\n\n## Why is this bad?\nPure class variables and instance variables have different access and\nassignment behavior. Overriding one with the other violates the\n[Liskov Substitution Principle] (\"LSP\"), because code that is valid for\nthe superclass may no longer be valid for the subclass.\n\n## Example\n```python\nfrom typing import ClassVar\n\nclass Base:\n    instance_attr: int\n    class_attr: ClassVar[int]\n\nclass Sub(Base):\n    instance_attr: ClassVar[int]  # error: [invalid-attribute-override]\n    class_attr: int  # error: [invalid-attribute-override]\n```\n\n[Liskov Substitution Principle]: https://en.wikipedia.org/wiki/Liskov_substitution_principle",
+          "default": "error",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Level"
+            }
+          ]
+        },
         "invalid-await": {
           "title": "detects awaiting on types that don't support it",
           "description": "## What it does\nChecks for `await` being used with types that are not [Awaitable].\n\n## Why is this bad?\nSuch expressions will lead to `TypeError` being raised at runtime.\n\n## Examples\n```python\nimport asyncio\n\nclass InvalidAwait:\n    def __await__(self) -> int:\n        return 5\n\nasync def main() -> None:\n    await InvalidAwait()  # error: [invalid-await]\n    await 42  # error: [invalid-await]\n\nasyncio.run(main())\n```\n\n[Awaitable]: https://docs.python.org/3/library/collections.abc.html#collections.abc.Awaitable",

--- a/tools/sync.py
+++ b/tools/sync.py
@@ -12,7 +12,7 @@ import datetime
 import json
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import aiohttp
 import tomlkit
@@ -21,11 +21,43 @@ DIR = Path(__file__).parent.resolve()
 RESOURCES = DIR.parent / "src/validate_pyproject_schema_store/resources"
 RESOURCES.mkdir(parents=True, exist_ok=True)
 
+PYPROJECT_URL = "https://json.schemastore.org/pyproject.json"
 
-async def get_url(session: aiohttp.ClientSession, url: str) -> dict[str, Any]:
+
+def resolve_ref(ref: str, base: str) -> str:
+    """Resolve a potentially relative $ref against a base URL."""
+    if ref.startswith(("http://", "https://", "#")):
+        return ref
+    return urljoin(base, ref)
+
+
+def resolve_schema_refs(obj: Any, base_url: str) -> Any:
+    """Recursively resolve all relative $ref URLs in a schema object to absolute URLs."""
+    if isinstance(obj, dict):
+        new = {}
+        for k, v in obj.items():
+            if k == "$ref" and isinstance(v, str):
+                new[k] = resolve_ref(v, base_url)
+            else:
+                new[k] = resolve_schema_refs(v, base_url)
+        return new
+    if isinstance(obj, list):
+        return [resolve_schema_refs(item, base_url) for item in obj]
+    return obj
+
+
+async def get_url(
+    session: aiohttp.ClientSession,
+    url: str,
+    resolve_refs: bool = False,
+    base_url: str = "",
+) -> dict[str, Any]:
     print("Getting", url)
     async with session.get(url) as resp:
-        return await resp.json()  # type: ignore[no-any-return]
+        data = await resp.json()
+        if resolve_refs:
+            data = resolve_schema_refs(data, base_url or url)
+        return data  # type: ignore[no-any-return]
 
 
 def schema_name_from_url(url: str) -> str:
@@ -77,28 +109,41 @@ async def main() -> None:
         res_json = await get_url(session, "https://json.schemastore.org/pyproject.json")
 
         tool_properties = await get_tool(session, res_json["properties"]["tool"])
-        tool_table = {t: d["$ref"] for t, d in tool_properties.items() if "$ref" in d}
+        tool_table = {
+            t: resolve_ref(d["$ref"], PYPROJECT_URL)
+            for t, d in tool_properties.items()
+            if "$ref" in d
+        }
 
         tool_json = RESOURCES / "tool.json"
         changed |= write_if_changed(tool_json, tool_table)
         nested = {}
 
-        # Track which URLs we've already downloaded to handle aliases (multiple tools -> same URL)
+        # Track which URLs we've already downloaded to handle aliases
         url_to_filename: dict[str, str] = {}
 
         async with asyncio.TaskGroup() as tg:
             results = {
-                tool: tg.create_task(get_url(session, ref.partition("#")[0]))
+                tool: tg.create_task(
+                    get_url(
+                        session,
+                        ref.partition("#")[0],
+                        resolve_refs=True,
+                        base_url=PYPROJECT_URL,
+                    )
+                )
                 for tool, ref in tool_table.items()
             }
 
         for tool, future in results.items():
             ref = tool_table[tool]
             result = future.result()
+            base_url = ref.partition("#")[0]
 
             nested_names = {
                 schema_name_from_url(url)
-                for url in iter_schema_refs(result)
+                for raw_url in iter_schema_refs(result)
+                for url in [resolve_ref(raw_url, base_url)]
                 if url.startswith(
                     (
                         "https://json.schemastore.org/",
@@ -128,7 +173,8 @@ async def main() -> None:
 
             target = RESOURCES / f"{target_name}.schema.json"
 
-            for url in iter_schema_refs(result):
+            for raw_url in iter_schema_refs(result):
+                url = resolve_ref(raw_url, base_url)
                 if url.startswith(
                     (
                         "https://json.schemastore.org/",
@@ -139,7 +185,9 @@ async def main() -> None:
                         continue
                     filename = schema_name_from_url(url)
                     nested_target = RESOURCES / f"{filename}.schema.json"
-                    nested_result = await get_url(session, url)
+                    nested_result = await get_url(
+                        session, url, resolve_refs=True, base_url=PYPROJECT_URL
+                    )
                     changed |= write_if_changed(nested_target, nested_result)
                     nested[filename] = url
 


### PR DESCRIPTION
I fixed a warning in the CI, and also the following:

:robot: SchemaStore's `pyproject.json` changed its `$ref` values from absolute URLs (e.g. `https://json.schemastore.org/partial-black.json`) to relative ones (e.g. `partial-black.json`). The sync script was passing those bare filenames straight to `aiohttp`, causing `InvalidUrlClientError` for every tool schema.

1. **`resolve_ref(ref, base)`** — resolves relative `$ref`s to absolute URLs using `urljoin`.
2. **`resolve_schema_refs(obj, base_url)`** — recursively walks downloaded JSON and resolves every relative `$ref` to absolute before writing it to disk.
3. **`tool_table` construction** — now resolves tool `$ref`s against `pyproject.json` so `tool.json` stores absolute URLs.
4. **Fetching tool & nested schemas** — both now pass `resolve_refs=True`, so internal relative references (like `partial-pdm-dockerize.json` inside `pdm.json`) are stored as absolute URLs.
5. **Fragment-only refs (`#...`)** — are left untouched so internal pointers within `pyproject.json` aren't incorrectly resolved.

This also fixes the downstream issue where relative `$ref`s inside saved schemas caused `validate-pyproject` to fail validation for tools like `pdm` and `ruff`.

Assisted-by: OpenCode:Kimi-K2.6
Signed-off-by: Henry Schreiner <henryfs@princeton.edu>
