### PR TITLE
Remove stale type: ignore comments that break mypy in pre-commit CI

### DIFF
--- a/tools/sync.py
+++ b/tools/sync.py
@@ -215,8 +215,8 @@ async def main() -> None:
             for tool in tool_table:
                 if tool not in {"setuptools", "distutils"} and tool in canonical_tools:
                     table.add(tool, "validate_pyproject_schema_store.schema:get_schema")
-            doc["project"]["entry-points"]["validate_pyproject.tool_schema"] = table  # type: ignore[index]
-            doc["project"]["version"] = f"{datetime.date.today():%Y.%m.%d}"  # type: ignore[index]
+            doc["project"]["entry-points"]["validate_pyproject.tool_schema"] = table
+            doc["project"]["version"] = f"{datetime.date.today():%Y.%m.%d}"
             pyproject.write_text(tomlkit.dumps(doc))
 
 


### PR DESCRIPTION
## Summary

- A recent mypy update added support for indexing `tomlkit` documents, making two `# type: ignore[index]` suppressions in `tools/sync.py` stale.
- mypy now raises `unused-ignore` errors on those lines, failing the pre-commit CI hook.
- Fix is to simply remove the two now-unnecessary comments.

## Test plan

- [ ] `pre-commit run mypy -a` passes locally after the change


---
_Generated by [Claude Code](https://claude.ai/code/session_015EFLUYnMDk4WH3Uv3aHR5W)_