### PR TITLE
fix: limit fastjsonschmema on 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
   "Topic :: Software Development :: Quality Assurance",
   "Typing :: Typed",
 ]
+dependencies = ["fastjsonschema!=2.22.0; python_version<'3.10'"]
 
 [project.optional-dependencies]
 validate-pyproject = [


### PR DESCRIPTION
Fix for recent release not having python_requries set.

See https://github.com/horejsek/python-fastjsonschema/issues/211.