### PR TITLE
chore: secure CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -2,32 +2,43 @@ name: Create release on pyproject-schema-store-bot merge
 on:
   pull_request:
     types: [closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
 jobs:
   create-release:
+    name: Create release
     if:
       github.event.pull_request.merged == true &&
       github.event.pull_request.user.login == 'pyproject-schema-store-bot[bot]'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # push the tag and create the release
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: true # the tag push below uses these credentials
       - name: Get version from pyproject.toml
         id: get_version
-        uses: mikefarah/yq@v4
+        uses: mikefarah/yq@1b9b4ac5187171d2e5e3129be0cfa827c7f9d53d # v4.53.3
         with:
           cmd: yq .project.version pyproject.toml
       - name: Create git tag
         run: |
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
-          git tag ${{ steps.get_version.outputs.result }}
-          git push origin ${{ steps.get_version.outputs.result }}
+          git tag "$VERSION"
+          git push origin "$VERSION"
+        env:
+          VERSION: ${{ steps.get_version.outputs.result }}
       - name: Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: ${{ steps.get_version.outputs.result }}
           token: ${{ secrets.token }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -8,28 +8,34 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   bump:
     name: Bump rendered version if changed
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # push the branch for the bump PR
+      pull-requests: write # open and auto-merge the bump PR
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: generate-token
         with:
           client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run bump script
         run: |
@@ -49,7 +55,7 @@ jobs:
           with open(os.environ["GITHUB_OUTPUT"], "w", encoding="utf-8") as f:
               print(f"version={pyproject['project']['version']}", file=f)
 
-      - uses: peter-evans/create-pull-request@v8
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         id: create-pr
         with:
           title: |
@@ -69,8 +75,7 @@ jobs:
         id: check-commits
         if: steps.create-pr.outputs.pull-request-number
         run: |
-          pr_number=${{ steps.create-pr.outputs.pull-request-number }}
-          commits=$(gh api repos/${{ github.repository }}/pulls/$pr_number/commits --jq '[.[].author.login? // "unknown"]')
+          commits=$(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --jq '[.[].author.login? // "unknown"]')
           unique_authors=$(echo "$commits" | jq -c 'unique')
           echo "authors=$unique_authors" >> "$GITHUB_OUTPUT"
           if [[ "$unique_authors" == '["pyproject-schema-store-bot[bot]"]' ]]; then
@@ -81,12 +86,15 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.token }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+          REPO: ${{ github.repository }}
 
       - name: Enable pull request auto-merge
         if:
           steps.create-pr.outputs.pull-request-number &&
           steps.check-commits.outputs.only-bot == 'true'
         run: |
-          gh pr merge --squash --auto --delete-branch ${{ steps.create-pr.outputs.pull-request-number }}
+          gh pr merge --squash --auto --delete-branch "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.token }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,34 +25,34 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
 
   publish:
     needs: [dist]
     name: Publish to PyPI
     environment: pypi
     permissions:
-      id-token: write
-      attestations: write
+      id-token: write # trusted publishing to PyPI
+      attestations: write # generate build provenance
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages
           path: dist
 
       - name: Generate artifact attestation for sdist and wheel
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: "dist/*"
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           attestations: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
         runs-on: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           allow-prereleases: true
           python-version: |
@@ -43,18 +43,19 @@ jobs:
             3.14
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v9.0.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Test package
         run: uvx hatch test -ca
 
   pass:
+    name: Pass
     if: always()
     needs: [checks]
     runs-on: ubuntu-slim
     timeout-minutes: 2
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,7 @@
+rules:
+  superfluous-actions:
+    ignore:
+      # `gh pr create` cannot sign commits; the action can.
+      - bump.yml
+      # The action is kept on purpose; it is pinned to a commit SHA.
+      - auto-release.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,13 @@ ci:
 
 repos:
   - repo: https://github.com/adamchainz/blacken-docs
-    rev: "1.20.0"
+    rev: "fda77690955e9b63c6687d8806bafd56a526e45f" # frozen: 1.20.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==24.*]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v6.0.0"
+    rev: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c" # frozen: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -27,7 +27,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: "v3.9.4"
+    rev: "0ee178619d696787ca73d210cc191d720868c631" # frozen: v3.9.6
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]
@@ -35,14 +35,14 @@ repos:
         exclude: '^src/validate_pyproject_schema_store/resources/.*\.json'
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.20"
+    rev: "39d9ac5938dadb73df0564a45f163e25ff9fa6e2" # frozen: v0.16.1
     hooks:
       - id: ruff-check
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v2.1.0"
+    rev: "41e691678310dfd3833f7ab4e180ddb014310356" # frozen: v2.3.0
     hooks:
       - id: mypy
         files: src|tests|tools
@@ -55,13 +55,13 @@ repos:
           - validate_pyproject
 
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.4.2"
+    rev: "57b21406f092110c18776e39b0bda50d37c945c8" # frozen: v2.4.3
     hooks:
       - id: codespell
         args: ["-Lcrate"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: "v0.11.0.1"
+    rev: "745eface02aef23e168a8afb6b5737818efbea95" # frozen: v0.11.0.1
     hooks:
       - id: shellcheck
 
@@ -74,18 +74,25 @@ repos:
         exclude: .pre-commit-config.yaml
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.25
+    rev: 4b2e70d08cb2ccd26d1fba73588de41c7a5d50b7 # frozen: v0.25
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.37.4
+    rev: 6b63472e72e1a91ed8a2f6d483790dfb644fa1d3 # frozen: 0.37.4
     hooks:
       - id: check-dependabot
       - id: check-github-workflows
       - id: check-readthedocs
 
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: "451b56af716f9f0d0c2b816503a3fd0cf8b036fa" # frozen: v1.29.0
+    hooks:
+      - id: zizmor
+        files: "^\\.github"
+        args: [--persona=pedantic]
+
   - repo: https://github.com/scientific-python/cookie
-    rev: 2026.06.18
+    rev: 8f0581cc50b14023b14a9c77e9b358738ba637e7 # frozen: 2026.06.18
     hooks:
       - id: sp-repo-review

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,9 @@ validate-pyproject-schema-store = "validate_pyproject_schema_store.schema:get_mu
 [project.entry-points."pipx.run"]
 validate-pyproject-schema-store = "validate_pyproject.cli:main"
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.hatch.envs.default]
 installer = "uv"
 

--- a/src/validate_pyproject_schema_store/schema.py
+++ b/src/validate_pyproject_schema_store/schema.py
@@ -47,9 +47,7 @@ def _url_to_canonical_tool() -> dict[str, str]:
         url_to_tools[canonical_url].append(tool)
 
     # Pick the first tool name in alphabetical order
-    return {
-        url: sorted(tools_for_url)[0] for url, tools_for_url in url_to_tools.items()
-    }
+    return {url: min(tools_for_url) for url, tools_for_url in url_to_tools.items()}
 
 
 def _load_schema(filename: str) -> dict[str, Any]:

--- a/tools/sync.py
+++ b/tools/sync.py
@@ -209,14 +209,16 @@ async def main() -> None:
                     url_to_tools[canonical_url] = []
                 url_to_tools[canonical_url].append(tool)
 
-            canonical_tools = {sorted(tools)[0] for tools in url_to_tools.values()}
+            canonical_tools = {min(tools) for tools in url_to_tools.values()}
 
             table = tomlkit.table()
             for tool in tool_table:
                 if tool not in {"setuptools", "distutils"} and tool in canonical_tools:
                     table.add(tool, "validate_pyproject_schema_store.schema:get_schema")
             doc["project"]["entry-points"]["validate_pyproject.tool_schema"] = table
-            doc["project"]["version"] = f"{datetime.date.today():%Y.%m.%d}"
+            doc["project"]["version"] = (
+                f"{datetime.datetime.now(tz=datetime.timezone.utc):%Y.%m.%d}"
+            )
             pyproject.write_text(tomlkit.dumps(doc))
 
 


### PR DESCRIPTION
Prompted by https://github.com/pypa/hatch/issues/2292.

:robot: _AI text below_ :robot:

- Pin all GitHub Actions to commit SHAs with version comments (`actions-up`, 7-day cooldown). `hynek/build-and-inspect-python-package` moves to v3, which stops force-tagging major versions.
- Add `.github/zizmor.yaml` and a pinned `zizmor` pre-commit hook, both with the pedantic persona. `uvx zizmor --persona=pedantic .github` is clean.
- Add `permissions: {}` at the workflow level in `auto-release.yml` and `bump.yml`, and add a comment to each permission.
- Replace template expansion in `run` blocks with environment variables in `auto-release.yml` and `bump.yml`.
- Limit the GitHub App token in `bump.yml` to contents and pull-requests, and set `persist-credentials: false` on its checkout.
- Set `persist-credentials: true` on the `auto-release.yml` checkout, which pushes the tag.
- Add a workflow concurrency group to `auto-release.yml`, and names to the unnamed jobs.
- Set the Dependabot schedule to monthly and add a 7-day cooldown.
- Freeze all pre-commit hooks to SHAs with a 7-day cooldown.
- Add `exclude-newer = "7 days"` to `[tool.uv]`.
- Fix two lint errors that the newer ruff finds (`sorted(x)[0]` to `min(x)`, and a timezone-aware date).

Deploy jobs in `cd.yml` are already isolated from the build job, so no change was necessary there.

`superfluous-actions` is ignored for two files: `create-pull-request` can sign commits and `gh pr create` cannot, and `action-gh-release` is kept as-is to avoid a change to release behavior. Both are pinned to SHAs.