### PR TITLE
chore: use `gh release create` instead of an action

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -38,7 +38,9 @@ jobs:
         env:
           VERSION: ${{ steps.get_version.outputs.result }}
       - name: Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: ${{ steps.get_version.outputs.result }}
-          token: ${{ secrets.token }}
+        run: gh release create "$VERSION" --verify-tag --generate-notes
+        env:
+          # A PAT, so that the release event starts the CD workflow.
+          GH_TOKEN: ${{ secrets.token }}
+          GH_REPO: ${{ github.repository }}
+          VERSION: ${{ steps.get_version.outputs.result }}

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -3,5 +3,3 @@ rules:
     ignore:
       # `gh pr create` cannot sign commits; the action can.
       - bump.yml
-      # The action is kept on purpose; it is pinned to a commit SHA.
-      - auto-release.yml


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The zizmor `superfluous-actions` audit recommends the GitHub CLI over `softprops/action-gh-release`. Replace the action with `gh release create` and remove the `auto-release.yml` ignore from `.github/zizmor.yaml`.

- `secrets.token` stays (as `GH_TOKEN`); the built-in token cannot start the CD workflow from a `release` event.
- `--verify-tag` makes the step fail if the tag push above did not work.
- `--generate-notes` adds an auto-generated changelog, which uses the existing `.github/release.yml` config. Releases had an empty body before.