### PR TITLE
chore: sync config with scientific-python/cookie

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,6 @@ ci:
   autoupdate_schedule: "monthly"
 
 repos:
-  - repo: https://github.com/adamchainz/blacken-docs
-    rev: "fda77690955e9b63c6687d8806bafd56a526e45f" # frozen: 1.20.0
-    hooks:
-      - id: blacken-docs
-        additional_dependencies: [black==24.*]
-
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "3e8a8703264a2f4a69428a0aa4dcb512790b2c8c" # frozen: v6.0.0
     hooks:
@@ -40,6 +34,7 @@ repos:
       - id: ruff-check
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
+        types_or: [python, pyi, jupyter, markdown, pyproject]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "41e691678310dfd3833f7ab4e180ddb014310356" # frozen: v2.3.0
@@ -59,6 +54,8 @@ repos:
     hooks:
       - id: codespell
         args: ["-Lcrate"]
+        additional_dependencies:
+          - tomli; python_version<'3.11'
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: "745eface02aef23e168a8afb6b5737818efbea95" # frozen: v0.11.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,8 @@ dependency-groups = ["dev"]
 
 [tool.hatch.envs.hatch-test]
 dependency-groups = ["test"]
+# Overrides hatch's defaults, whose coverage pin needs Python 3.10
+dependencies = ["coverage[toml]"]
 
 [tool.hatch.envs.lint]
 dependencies = ["pre-commit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.26"]
 build-backend = "hatchling.build"
 
 
@@ -11,11 +11,12 @@ authors = [
 ]
 description = "A plugin set for validate-pyproject and schema-store."
 readme = "README.md"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
@@ -95,16 +96,10 @@ exclude-newer = "7 days"
 
 [tool.hatch.envs.default]
 installer = "uv"
+dependency-groups = ["dev"]
 
 [tool.hatch.envs.hatch-test]
-# Duplicated waiting for dependency-group support
-dependencies = [
-  "pytest >=6",
-  "pytest-cov >=3",
-  "validate-pyproject >=0.24.1",
-  "tomli; python_version<'3.11'",
-  "packaging",
-]
+dependency-groups = ["test"]
 
 [tool.hatch.envs.lint]
 dependencies = ["pre-commit"]
@@ -133,7 +128,7 @@ testpaths = [
 
 [tool.coverage]
 run.source = ["validate_pyproject_schema_store"]
-port.exclude_lines = [
+report.exclude_also = [
   'pragma: no cover',
   '\.\.\.',
   'if typing.TYPE_CHECKING:',
@@ -206,4 +201,5 @@ messages_control.disable = [
 ]
 
 [tool.repo-review]
-ignore = ["RTD", "PY004", "PC170"]
+# PC111: ruff-format handles docs code blocks; drop after the next cookie release
+ignore = ["RTD", "PY004", "PC170", "PC111"]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Brings the config back in line with the current `scientific-python/cookie`
template.

- `tool.coverage.port.exclude_lines` was a dead key that coverage ignored. It
  is now `report.exclude_also`. The three patterns are coverage defaults, so
  the effective behavior does not change.
- The `hatch-test` env uses `dependency-groups` instead of a duplicated copy of
  the `test` group. The stale "waiting for dependency-group support" comment is
  gone.
- The license uses PEP 639 (`license = "Apache-2.0"` plus `license-files`)
  instead of the deprecated classifier. This needs `hatchling>=1.26`. The built
  wheel gives `Metadata-Version: 2.4`, `License-Expression: Apache-2.0`, and
  keeps `LICENSE` in `.dist-info/licenses/`.
- `blacken-docs` is removed. `ruff-format` formats code blocks in Markdown as
  of Ruff 0.16, which the pinned 0.16.1 does.
- `codespell` gets its `tomli` dependency for Python 3.10 and below.

`PC111` is added to the repo-review ignore list. The check accepts
`ruff-format` in place of `blacken-docs` on cookie `main`, but not in the
pinned 2026.06.18 release. Remove the ignore after the next cookie release.
