### PR TITLE
chore: enable the full ruff ruleset

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     rev: "39d9ac5938dadb73df0564a45f163e25ff9fa6e2" # frozen: v0.16.1
     hooks:
       - id: ruff-check
-        args: ["--fix", "--show-fixes"]
+        args: ["--fix"]
       - id: ruff-format
         types_or: [python, pyi, jupyter, markdown, pyproject]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,41 +152,23 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 
 
-[tool.ruff.lint]
-extend-select = [
-  "B",           # flake8-bugbear
-  "I",           # isort
-  "ARG",         # flake8-unused-arguments
-  "C4",          # flake8-comprehensions
-  "EM",          # flake8-errmsg
-  "ISC",
-  "ICN",         # flake8-import-conventions
-  "G",           # flake8-logging-format
-  "PGH",         # pygrep-hooks
-  "PIE",         # flake8-pie
-  "PL",          # pylint
-  "PT",          # flake8-pytest-style
-  "PTH",         # flake8-use-pathlib
-  "RET",         # flake8-return
-  "RUF",         # Ruff-specific
-  "SIM",         # flake8-simplify
-  "T20",         # flake8-print
-  "UP",          # pyupgrade
-  "YTT",         # flake8-2020
-  "EXE",         # flake8-executable
-  "NPY",         # NumPy specific rules
-  "PD",          # pandas-vet
+[tool.ruff]
+show-fixes = true
+lint.select = ["ALL"]
+lint.ignore = [
+  "ANN401",  # Disallow Any
+  "COM812",  # Trailing commas teach the formatter
+  "CPY001",  # Missing copyright notice
+  "E501",    # Line too long, the formatter handles what it can
+  "PLR09",   # Too many ...
+  "S101",    # Assert is used by mypy and pytest
 ]
-ignore = [
-  "PLR",    # Design related pylint codes
-  "ISC001", # Conflicts with formatter
-  "EXE003", # Doesn't support uv
-]
-isort.required-imports = ["from __future__ import annotations"]
+lint.isort.required-imports = ["from __future__ import annotations"]
+lint.pydocstyle.convention = "pep257"
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = ["T20"]
-"tools/**" = ["T20"]
+"tests/**" = ["D1", "INP001", "T20"]
+"tools/**" = ["C901", "T20"]
 
 
 [tool.pylint]

--- a/src/validate_pyproject_schema_store/schema.py
+++ b/src/validate_pyproject_schema_store/schema.py
@@ -1,3 +1,5 @@
+"""Entry points that supply schema-store schemas to validate-pyproject."""
+
 from __future__ import annotations
 
 import functools

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -5,7 +5,7 @@ import pytest
 from validate_pyproject_schema_store.schema import get_multi_schema, get_schema
 
 
-def test_get_unknown_schema():
+def test_get_unknown_schema() -> None:
     with pytest.raises(AssertionError):
         get_schema("unknown")
 
@@ -13,7 +13,7 @@ def test_get_unknown_schema():
 @pytest.mark.parametrize(
     "tool", ["poetry", "cibuildwheel", "mypy", "pdm", "scikit-build", "setuptools"]
 )
-def test_get_schema_partials(tool: str):
+def test_get_schema_partials(tool: str) -> None:
     schema = get_schema(tool)
     assert schema["$id"] == f"https://json.schemastore.org/partial-{tool}.json"
     assert schema["$schema"] == "http://json-schema.org/draft-07/schema#"
@@ -21,21 +21,21 @@ def test_get_schema_partials(tool: str):
 
 
 @pytest.mark.parametrize("tool", ["hatch", "ruff"])
-def test_get_schema_full(tool: str):
+def test_get_schema_full(tool: str) -> None:
     schema = get_schema(tool)
     assert schema["$id"] == f"https://json.schemastore.org/{tool}.json"
     assert schema["$schema"] == "http://json-schema.org/draft-07/schema#"
     assert "properties" in schema
 
 
-def test_no_nested_schema():
+def test_no_nested_schema() -> None:
     schema = get_schema("pdm")
     properties = schema["properties"]
     for prop in properties.values():
         assert not prop.get("$ref", "")
 
 
-def test_multi_schema():
+def test_multi_schema() -> None:
     multi_schema = get_multi_schema()
     assert (
         multi_schema["tools"]["ruff"]["$id"] == "https://json.schemastore.org/ruff.json"

--- a/tests/test_validate_pyproject.py
+++ b/tests/test_validate_pyproject.py
@@ -12,7 +12,7 @@ else:
     import tomllib
 
 
-def test_vpp_loads(caplog):
+def test_vpp_loads(caplog: pytest.LogCaptureFixture) -> None:
     pyproject_as_dict = tomllib.loads("""
         [tool.ruff]
         src = ["src"]
@@ -26,7 +26,7 @@ def test_vpp_loads(caplog):
     )
 
 
-def test__loads(caplog):
+def test__loads(caplog: pytest.LogCaptureFixture) -> None:
     pyproject_as_dict = tomllib.loads("""
         [tool.hatch.env]
         requires = [
@@ -42,7 +42,7 @@ def test__loads(caplog):
     )
 
 
-def test_version_24_multi():
+def test_version_24_multi() -> None:
     pyproject_as_dict = tomllib.loads("""
         [tool.pdm]
         dockerize.anything = "invalid"

--- a/tools/sync.py
+++ b/tools/sync.py
@@ -5,6 +5,8 @@
 # ///
 
 
+"""Download the schema-store schemas and refresh the bundled resources."""
+
 from __future__ import annotations
 
 import asyncio
@@ -49,9 +51,11 @@ def resolve_schema_refs(obj: Any, base_url: str) -> Any:
 async def get_url(
     session: aiohttp.ClientSession,
     url: str,
+    *,
     resolve_refs: bool = False,
     base_url: str = "",
 ) -> dict[str, Any]:
+    """Download a JSON document, optionally making its $refs absolute."""
     print("Getting", url)
     async with session.get(url) as resp:
         data = await resp.json()
@@ -61,11 +65,13 @@ async def get_url(
 
 
 def schema_name_from_url(url: str) -> str:
+    """Return the schema file stem from a schema URL."""
     parsed = urlparse(url.partition("#")[0])
     return Path(parsed.path).name.removesuffix(".json")
 
 
 def iter_schema_refs(value: Any) -> set[str]:
+    """Collect every $ref string in a schema object."""
     refs: set[str] = set()
     if isinstance(value, dict):
         ref = value.get("$ref")
@@ -80,6 +86,7 @@ def iter_schema_refs(value: Any) -> set[str]:
 
 
 def write_if_changed(filename: Path, contents: dict[str, Any]) -> bool:
+    """Write the JSON file if the contents differ; report if it changed."""
     new = json.dumps(contents, indent=2) + "\n"
     new = new.replace(
         '"uint64"', '"uint"'
@@ -94,6 +101,7 @@ def write_if_changed(filename: Path, contents: dict[str, Any]) -> bool:
 async def get_tool(
     session: aiohttp.ClientSession, tools: dict[str, Any]
 ) -> dict[str, Any]:
+    """Return the tool table properties, following a $ref if needed."""
     try:
         return tools["properties"]  # type: ignore[no-any-return]
     except KeyError:
@@ -103,6 +111,7 @@ async def get_tool(
 
 
 async def main() -> None:
+    """Refresh the bundled schemas, entry points, and version."""
     changed = False
 
     async with aiohttp.ClientSession() as session:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Switch ruff to `lint.select = ["ALL"]` and resolve everything it reports.

Fixed in code:
- Module docstrings for `schema.py` and `tools/sync.py`, plus docstrings for the public functions in `sync.py`
- Return annotations on the tests, and `caplog: pytest.LogCaptureFixture`
- `get_url`'s `resolve_refs`/`base_url` are now keyword-only (FBT001/FBT002); every call site already used keywords

Ignored instead:
- `E501` globally — ruff-format wraps what it can, the rest are long URLs and message strings
- `D1` and `INP001` for `tests/**` — test names carry the intent, and a `tests/__init__.py` would be wrong
- `C901` for `tools/**` — `main` is a linear script body

`--show-fixes` moves from the pre-commit args to `[tool.ruff]` so it applies to direct runs too.