### PR TITLE
chore: add Python 3.15 to testing and classifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
             3.12
             3.13
             3.14
+            3.15
 
       - name: Setup uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Software Development :: Quality Assurance",
   "Typing :: Typed",
 ]
@@ -113,7 +114,7 @@ dependencies = ["pylint"]
 scripts.lint = "pylint validate_pyproject_schema_store {args}"
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.14", "3.13", "3.12", "3.11", "3.10", "3.9"]
+python = ["3.15", "3.14", "3.13", "3.12", "3.11", "3.10", "3.9"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Adds Python 3.15 to the trove classifiers, the hatch test matrix, and the CI `setup-python` list. Prereleases are already allowed in CI.

Tests pass locally on 3.15.0b4.